### PR TITLE
test flexible build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,5 +35,5 @@
     }
   },
   // Needed for git security feature (this assumes you locally cloned to flux-core)
-  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-core"
+  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-python"
 }

--- a/.github/scripts/check_releases.py
+++ b/.github/scripts/check_releases.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import requests
+import tempfile
+import re
+import shutil
+import sys
+import os
+
+# Get all versions of package from pypi
+# python script/get_releases.py flux-framework
+
+token = os.environ.get("GITHUB_TOKEN")
+headers = {}
+if token:
+    headers["Authorization"] = "token %s" % token
+
+
+def set_env_and_output(name, value):
+    """
+    helper function to echo a key/value pair to output and env.
+
+    Parameters:
+    name (str)  : the name of the environment variable
+    value (str) : the value to write to file
+    """
+    for env_var in ("GITHUB_ENV", "GITHUB_OUTPUT"):
+        environment_file_path = os.environ.get(env_var)
+        print("Writing %s=%s to %s" % (name, value, env_var))
+
+        with open(environment_file_path, "a") as environment_file:
+            environment_file.write("%s=%s\n" % (name, value))
+
+
+class PackageUpdater:
+    def __init__(
+        self, package, version=None, dry_run=False, repo="flux-framework/flux-core"
+    ):
+        self.package = package
+        self.dry_run = dry_run
+        self.version = version
+        self.repo = repo
+
+    def check(self):
+        """
+        Given a package directory and repository name, check for new releases.
+        """
+        releases = self.get_github_releases()
+
+        # The latest tag
+        tag = releases[0]["tag_name"]
+        if self.version is not None:
+            tag = self.version
+
+        # Get releases from pypi
+        pypi_releases = self.get_pypi_releases()
+
+        # Some versions are prefixed with v
+        tags = [tag, tag.lstrip("v")]
+
+        # If it's a dry run OR we don't have it
+        if self.dry_run or (
+            tags[0] not in pypi_releases and tags[1] not in pypi_releases
+        ):
+            print(f"New version {tag} detected or dry run is set!")
+            set_env_and_output("version", tag)
+            set_env_and_output("build", "true")
+            set_env_and_output("dry-run", self.dry_run)
+        else:
+            print(f"Tag {tag} is already released and dry run is false")
+
+    def get_pypi_releases(self):
+        """
+        Get releases to pypi
+        """
+        res = requests.get(f"https://pypi.org/pypi/{self.package}/json")
+        if res.status_code == 404:
+            return []
+        if res.status_code != 200:
+            sys.exit(f"Issue getting pypi releases: {res.txt}")
+        res = res.json()
+
+        # earliest (index 0) to latest (index -1)
+        return list(res["releases"])
+
+    def get_github_releases(self):
+        """
+        Get the lateset release of a repository (under flux-framework)
+        """
+        url = f"https://api.github.com/repos/{self.repo}/releases"
+        response = requests.get(url, headers=headers, params={"per_page": 100})
+        response.raise_for_status()
+
+        # latest release should be first
+        return response.json()
+
+    def download_archive(self, naked_version, download_path):
+        """
+        Download an archive tarball.
+        """
+        tarball_url = (
+            f"https://github.com/{self.repo}/archive/refs/tags/{naked_version}.tar.gz"
+        )
+        return self.download(tarball_url, download_path)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Spack Updater for Releases",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("package", help="name of pypi package")
+    parser.add_argument("--version", help="version of flux to target")
+    parser.add_argument(
+        "--repo", default="flux-framework/flux-core", help="repository with releases"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Don't write changes to file",
+    )
+    return parser
+
+
+def main():
+    parser = get_parser()
+
+    # If an error occurs while parsing the arguments, the interpreter will exit with value 2
+    args, extra = parser.parse_known_args()
+
+    # Show args to the user
+    print("        repo: %s" % args.repo)
+    print("     package: %s" % args.package)
+    print("     dry-run: %s" % args.dry_run)
+    if args.version:
+        print("     version: %s" % args.version)
+
+    updater = PackageUpdater(args.package, args.version, args.dry_run)
+    updater.check()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# This will be empty for nightly test, and we will clone master branch
+echo "Flux Version is ${FLUX_VERSION}"
+
+here=$(pwd)
+sudo apt-get update
+sudo apt-get install -y \
+        libjson-glib-dev \
+        wget \
+        automake \
+        libsodium-dev \
+        libzmq3-dev \
+        libczmq-dev \
+        libjansson-dev \
+        libmunge-dev \
+        libncursesw5-dev \
+        lua5.4 \
+        liblua5.4-dev \
+        liblz4-dev \
+        libsqlite3-dev \
+        uuid-dev \
+        libhwloc-dev \
+        libmpich-dev \
+        libs3-dev \
+        libevent-dev \
+        libarchive-dev \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-sphinx \
+        libtool \
+        git \
+        build-essential \
+        libpam-dev
+
+sudo ldconfig
+sudo rm -rf /var/lib/apt/lists/*
+
+sudo python3 -m pip install IPython
+sudo python3 -m pip install -r .github/scripts/requirements-dev.txt
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/lib
+
+git clone https://github.com/flux-framework/flux-security ~/security
+cd ~/security
+./autogen.sh
+./configure --prefix=/usr/local
+make 
+sudo make install
+sudo ldconfig
+
+# This is a build from a release 
+if [[ "${FLUX_VERSION}" != "" ]]; then
+    echo "Flux version requested to build is ${FLUX_VERSION}"
+    wget https://github.com/flux-framework/flux-core/releases/download/v${FLUX_VERSION}/flux-core-${FLUX_VERSION}.tar.gz
+    tar -xzvf flux-core-${FLUX_VERSION}.tar.gz
+    sudo mv flux-core-${FLUX_VERSION} /code
+
+# Build from the current master branch
+else
+    sudo git clone https://github.com/flux-framework/flux-core /code
+fi
+sudo chown -R $USER /code
+cd /code
+chmod +x etc/gen-cmdhelp.py
+
+# This is only needed for non-releases
+./autogen.sh || echo "No autogen here"
+./configure --prefix=/usr/local
+make
+sudo make install
+sudo ldconfig   
+cd ${here}

--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -1,0 +1,54 @@
+name: build-manual flux-python
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of flux to build'
+        required: true
+      release_version:
+        description: 'Pypi version to release to'
+        required: true
+
+jobs:
+  build-manual:
+    runs-on: ubuntu-latest
+    services:
+      api:
+        image: fluxrm/testenv:focal
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Flux Core
+      env:
+        FLUX_VERSION: ${{ inputs.version }}
+      run: |
+        export FLUX_VERSION
+        /bin/bash .github/scripts/setup.sh
+
+    - name: Build Python Bindings
+      run: |
+        ls /code   
+        ls ./            
+        mv /code/src/bindings/python/flux ./flux
+        python3 setup.py sdist bdist_wheel --flux-root /code --security-src $HOME/security --security-include /usr/local/include/flux/security --version ${{ inputs.release_version }}
+        sudo ldconfig
+    
+    - name: Prepare Wheel
+      run: conda create --quiet --name env twine
+
+    - name: Install dependencies
+      run: |
+        export PATH="/usr/share/miniconda/bin:$PATH"
+        source activate env
+        pip install -e .
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USER }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
+      run: |
+        export PATH="/usr/share/miniconda/bin:$PATH"
+        source activate env
+        twine upload dist/*.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: build flux-python
+
+on:
+  push:
+    branches:
+      - doesnotexist
+
+  # TODO this will trigger nightly to check for releases, not active yet
+  # pull_request: []
+  # schedule:
+  #  - cron: "5 4 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      api:
+        image: fluxrm/testenv:focal
+    steps:
+    - uses: actions/checkout@v3    
+    # TODO add release check here to get version
+    - name: Build Flux Core
+      run: /bin/bash .github/scripts/setup.sh
+
+    - name: Build Python Bindings
+      run: |
+        mv /code/src/bindings/python/flux ./flux
+        python3 setup.py sdist bdist_wheel --flux-root /code --security-src $HOME/security --security-include /usr/local/include/flux/security --version develop

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,24 @@
+name: test-build flux-python
+
+on:
+  pull_request: []
+  schedule:
+    - cron: "5 4 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      api:
+        image: fluxrm/testenv:focal
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Flux Core
+      run: /bin/bash .github/scripts/setup.sh
+
+    - name: Build Python Bindings
+      run: |
+        mv /code/src/bindings/python/flux ./flux
+        python3 setup.py sdist bdist_wheel --flux-root /code --security-src $HOME/security --security-include /usr/local/include/flux/security --version develop
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ flux.egg-info
 .eggs
 _flux
 dist
+flux
+flux_python.egg-info/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/NOTICE.LLNS
+++ b/NOTICE.LLNS
@@ -1,0 +1,21 @@
+This work was produced under the auspices of the U.S. Department of
+Energy by Lawrence Livermore National Laboratory under Contract
+DE-AC52-07NA27344.
+
+This work was prepared as an account of work sponsored by an agency of
+the United States Government. Neither the United States Government nor
+Lawrence Livermore National Security, LLC, nor any of their employees
+makes any warranty, expressed or implied, or assumes any legal liability
+or responsibility for the accuracy, completeness, or usefulness of any
+information, apparatus, product, or process disclosed, or represents that
+its use would not infringe privately owned rights.
+
+Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the
+United States Government or Lawrence Livermore National Security, LLC.
+
+The views and opinions of authors expressed herein do not necessarily
+state or reflect those of the United States Government or Lawrence
+Livermore National Security, LLC, and shall not be used for advertising
+or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,63 @@
 # Flux Python Bindings
 
+> 🐍️ You called me?
+
 Hello! You've found the flux Python bindings, an experiment to build and deploy
 Flux to Pypi without needing to store code alongside Flux. The goal of
 this experiment is to test them separately. This was originally developed
 at [vsoch/flux-python](https://github.com/vsoch/flux-python) and has 
-been ported here to automate more officially.
+been ported here to automate more officially. The following guides might be useful
+to you:
 
+ - ⭐️ [Flux Framework Documentation](https://flux-framework.readthedocs.io)
+ - ⭐️ [Flux Projects](https://flux-framework.org)
+ - ⭐️ [Tutorials](https://flux-framework.readthedocs.io/en/latest/tutorials/index.html)
+ 
+ 
 ## Development
 
-We provide a [.devcontainer](.devcontainer) environment you can open in VSCode
+We provide a [.devcontainer](https://github.com/flux-framework/flux-python/tree/main/.devcontainer) environment you can open in VSCode
 to have an environment ready to go with Flux (and Flux Security). You can follow
 the instructions in the DevContainer to build the Flux Python bindings.
+By default, this environment installs the latest flux-core.
+If you want to build a custom version with Flux core you can do:
+
+```bash
+rm -rf ~/flux-core
+export FLUX_VERSION=0.46.0
+wget https://github.com/flux-framework/flux-core/releases/download/v${FLUX_VERSION}/flux-core-${FLUX_VERSION}.tar.gz
+tar -xzvf flux-core-${FLUX_VERSION}.tar.gz
+sudo mv flux-core-${FLUX_VERSION} ~/flux-core
+rm flux-core-${FLUX_VERSION}.tar.gz
+cd ~/flux-core
+./configure --prefix=/usr/local
+make
+sudo make install
+```
+
+And then build your custom wheel:
+
+```bash
+$ cd /workspaces/flux-python
+$ python3 setup.py sdist bdist_wheel --flux-root /home/vscode/flux-core --security-src /home/vscode/security --security-include /usr/local/include/flux/security --version 0.46.0-rc-0
+```
+
+And if you want to upload:
+
+```bash
+$ twine upload dist/*.tar.gz
+```
 
 ### Building Modules
 
 We will need to build the tarball providing paths to the flux-core and flux-security
 sources. This can be improved upon to just be one path if all the dependencies
-are provided with the flux install (and we don't need the source):
-
+are provided with the flux install (and we don't need the source). Note
+that we also provide a custom version for the pypi package:
 
 ```bash
 # Generate the wheel (requires pip install wheel)
-$ python3 setup.py sdist bdist_wheel --flux-root /home/vscode/flux-core --security-src /home/vscode/security --security-include /usr/local/include/flux/security
+$ python3 setup.py sdist bdist_wheel --flux-root /home/vscode/flux-core --security-src /home/vscode/security --security-include /usr/local/include/flux/security --version 0.46.0-rc-0
 ```
 
 You can then install the wheel (as a user or to the root)
@@ -54,9 +90,37 @@ import flux
 flux.Flux()
 ```
 
-More coming soon! We still need to:
+### Automation
 
- - [ ] some version checking
- - [ ] ability to build .tar.gz (needed flux deps to be removed)
+In order to (eventually) support a workflow to check for a release, get the release's
+flux assets and build, we have a [workflow script](.github/scripts/check_releases.py) that will:
 
+- Get the latest flux releases
+- Compare to the latest pypi releases
+- If there is a new release (from Flux on GitHub) not in pypi, build and release
 
+And the script also can take an optional version string that will find and build
+a version explicitly. You might (to test) do:
+
+```bash
+$ export GITHUB_TOKEN=xxxxxxxxxxxxx
+$ python .github/scripts/check_releases.py flux-framework --version 0.46.0
+```
+
+That basically checks if there should be a build. It will use the container provided
+here to install a custom version of flux core that builds the release.
+
+### Work in Progress
+
+@vsoch wants to try installing her test releases to a system somewhere, and figure
+out this issue with buidling a wheel (or maybe we don't want wheels after all):
+
+> HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
+>         Binary wheel 'flux_python-0.46.0rc0-cp38-cp38-linux_x86_64.whl' has an 
+>         unsupported platform tag 'linux_x86_64'. 
+
+#### Release
+
+SPDX-License-Identifier: LGPL-3.0
+
+LLNL-CODE-764420

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:22.04
+
+# This Dockerfile will be an on-demand builder for flux, with the entrypoint being a script that runs bash
+# after building flux
+
+ENV DEBIAN_FRONTEND=noninteractive
+# from root:
+# docker build -t ghcr.io/flux-framework/flux-python -f src/bindings/python/Dockerfile .
+# docker run -it ghcr.io/flux-framework/flux-python
+
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        automake \
+        libsodium-dev \
+        libzmq3-dev \
+        libczmq-dev \
+        libjansson-dev \
+        libmunge-dev \
+        libncursesw5-dev \
+        lua5.4 \
+        liblua5.4-dev \
+        liblz4-dev \
+        libsqlite3-dev \
+        uuid-dev \
+        libhwloc-dev \
+        libmpich-dev \
+        libs3-dev \
+        libevent-dev \
+        libarchive-dev \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-sphinx \
+        libtool \
+        git \
+        build-essential \
+        wget \
+        # Flux security
+        libjson-glib-1.0.0 \ 
+        libjson-glib-dev \ 
+        libpam-dev && \
+        ldconfig && \
+        rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code
+
+# Add flux-security directory
+RUN git clone https://github.com/flux-framework/flux-security /code/security && \
+    cd /code/security && \
+    ./autogen.sh && \    
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    ldconfig
+
+WORKDIR /code

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,17 @@ from setuptools import setup as _setup
 from distutils.core import setup, Command
 
 # Metadata
-package_name = "flux"
+package_name = "flux-python"
 package_version = "0.46.0"
-package_description = "Bindings to the flux resource manager API"
+package_description = "Python bindings for the flux resource manager API"
 package_url = "https://github.com/flux-framework/flux-python"
 package_keywords = "flux, job manager, orchestration, hpc"
+
+try:
+    with open("README.md") as filey:
+        package_long_description = filey.read()
+except Exception:
+    package_long_description = description
 
 # Setup variables for dependencies
 cffi_dep = "cffi>=1.1"
@@ -340,6 +346,7 @@ def get_parser():
     parser.add_argument(
         "--flux-root", dest="flux_root", help="Root to flux source code.", required=True
     )
+    parser.add_argument("--version", help="version to install", required=True)
     parser.add_argument(
         "--security-src",
         dest="security_src",
@@ -359,7 +366,7 @@ def clean_args():
     """
     Ensure we remove extra flags that the second installed won't know about.
     """
-    removed = ["--security-src", "--security-include", "--flux-root"]
+    removed = ["--security-src", "--security-include", "--flux-root", "--version"]
     cleaned = []
     contenders = copy.deepcopy(sys.argv)
     while contenders:
@@ -380,9 +387,14 @@ def setup():
     # If an error occurs while parsing the arguments, the interpreter will exit with value 2
     args, extra = parser.parse_known_args()
 
+    global package_version
     global flux_root
     global security_src
     global security_include
+
+    # Did we set a custom version
+    if args.version:
+        package_version = args.version
 
     flux_root = args.flux_root
     security_src = args.security_src
@@ -420,6 +432,8 @@ def setup():
         name=package_name,
         version=package_version,
         description=package_description,
+        long_description=package_long_description,
+        long_description_content_type="text/markdown",
         keywords=package_keywords,
         url=package_url,
         setup_requires=[cffi_dep],

--- a/src/_core_preproc.h
+++ b/src/_core_preproc.h
@@ -1,10 +1,10 @@
-# 1 "/workspaces/python/src/_core_clean.h"
+# 1 "/workspaces/flux-python/src/_core_clean.h"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
-# 1 "/workspaces/python/src/_core_clean.h"
-# 47 "/workspaces/python/src/_core_clean.h"
+# 1 "/workspaces/flux-python/src/_core_clean.h"
+# 47 "/workspaces/flux-python/src/_core_clean.h"
 typedef void (*flux_free_f)(void *arg);
 
 
@@ -13,7 +13,7 @@ typedef void (*flux_free_f)(void *arg);
 typedef struct {
     char text[160];
 } flux_error_t;
-# 97 "/workspaces/python/src/_core_clean.h"
+# 97 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_msg flux_msg_t;
 
 enum {
@@ -60,7 +60,7 @@ void flux_match_free (struct flux_match m);
 int flux_match_asprintf (struct flux_match *m,
                          const char *topic_glob_fmt,
                          ...);
-# 171 "/workspaces/python/src/_core_clean.h"
+# 171 "/workspaces/flux-python/src/_core_clean.h"
 flux_msg_t *flux_msg_create (int type);
 void flux_msg_destroy (flux_msg_t *msg);
 
@@ -169,7 +169,7 @@ int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 
 int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vunpack (const flux_msg_t *msg, const char *fmt, va_list ap);
-# 287 "/workspaces/python/src/_core_clean.h"
+# 287 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_msg_last_error (const flux_msg_t *msg);
 
 
@@ -255,7 +255,7 @@ void flux_msg_fprint_ts (FILE *f, const flux_msg_t *msg, double timestamp);
 
 
 const char *flux_msg_typestr (int type);
-# 382 "/workspaces/python/src/_core_clean.h"
+# 382 "/workspaces/flux-python/src/_core_clean.h"
 void flux_msg_route_enable (flux_msg_t *msg);
 
 
@@ -314,7 +314,7 @@ char *flux_msg_route_string (const flux_msg_t *msg);
 
 bool flux_msg_route_match_first (const flux_msg_t *msg1,
                                  const flux_msg_t *msg2);
-# 456 "/workspaces/python/src/_core_clean.h"
+# 456 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_handle_struct flux_t;
 
 typedef struct {
@@ -355,7 +355,7 @@ enum {
     FLUX_POLLOUT = 2,
     FLUX_POLLERR = 4,
 };
-# 509 "/workspaces/python/src/_core_clean.h"
+# 509 "/workspaces/flux-python/src/_core_clean.h"
 flux_t *flux_open (const char *uri, int flags);
 
 
@@ -391,7 +391,7 @@ int flux_opt_get (flux_t *h, const char *option, void *val, size_t len);
 
 
 void flux_comms_error_set (flux_t *h, flux_comms_error_f fun, void *arg);
-# 553 "/workspaces/python/src/_core_clean.h"
+# 553 "/workspaces/flux-python/src/_core_clean.h"
 void *flux_aux_get (flux_t *h, const char *name);
 int flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
 
@@ -413,7 +413,7 @@ uint32_t flux_matchtag_avail (flux_t *h);
 
 
 int flux_send (flux_t *h, const flux_msg_t *msg, int flags);
-# 582 "/workspaces/python/src/_core_clean.h"
+# 582 "/workspaces/flux-python/src/_core_clean.h"
 flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags);
 
 
@@ -428,14 +428,14 @@ int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
 
 
 int flux_pollevents (flux_t *h);
-# 606 "/workspaces/python/src/_core_clean.h"
+# 606 "/workspaces/flux-python/src/_core_clean.h"
 int flux_pollfd (flux_t *h);
 
 
 
 void flux_get_msgcounters (flux_t *h, flux_msgcounters_t *mcs);
 void flux_clr_msgcounters (flux_t *h);
-# 654 "/workspaces/python/src/_core_clean.h"
+# 654 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_buffer flux_buffer_t;
 
 
@@ -452,7 +452,7 @@ int flux_buffer_bytes (flux_buffer_t *fb);
 
 
 int flux_buffer_space (flux_buffer_t *fb);
-# 680 "/workspaces/python/src/_core_clean.h"
+# 680 "/workspaces/flux-python/src/_core_clean.h"
 int flux_buffer_readonly (flux_buffer_t *fb);
 bool flux_buffer_is_readonly (flux_buffer_t *fb);
 
@@ -460,9 +460,9 @@ bool flux_buffer_is_readonly (flux_buffer_t *fb);
 
 
 int flux_buffer_drop (flux_buffer_t *fb, int len);
-# 695 "/workspaces/python/src/_core_clean.h"
+# 695 "/workspaces/flux-python/src/_core_clean.h"
 const void *flux_buffer_peek (flux_buffer_t *fb, int len, int *lenp);
-# 705 "/workspaces/python/src/_core_clean.h"
+# 705 "/workspaces/flux-python/src/_core_clean.h"
 const void *flux_buffer_read (flux_buffer_t *fb, int len, int *lenp);
 
 
@@ -523,7 +523,7 @@ int flux_buffer_read_to_fd (flux_buffer_t *fb, int fd, int len);
 
 
 int flux_buffer_write_from_fd (flux_buffer_t *fb, int fd, int len);
-# 781 "/workspaces/python/src/_core_clean.h"
+# 781 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_reactor flux_reactor_t;
 
 
@@ -609,18 +609,12 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
 flux_buffer_t *flux_buffer_read_watcher_get_buffer (flux_watcher_t *w);
 
 
-
-
-const char *flux_buffer_read_watcher_get_data (flux_watcher_t *w,
-                                               int *lenp);
-
-
 flux_watcher_t *flux_buffer_write_watcher_create (flux_reactor_t *r, int fd,
                                                   int size, flux_watcher_f cb,
                                                   int flags, void *arg);
 
 flux_buffer_t *flux_buffer_write_watcher_get_buffer (flux_watcher_t *w);
-# 887 "/workspaces/python/src/_core_clean.h"
+# 881 "/workspaces/flux-python/src/_core_clean.h"
 int flux_buffer_write_watcher_close (flux_watcher_t *w);
 
 
@@ -698,7 +692,7 @@ struct flux_watcher_ops {
     void (*stop) (flux_watcher_t *w);
     void (*destroy) (flux_watcher_t *w);
 };
-# 972 "/workspaces/python/src/_core_clean.h"
+# 966 "/workspaces/flux-python/src/_core_clean.h"
 flux_watcher_t * flux_watcher_create (flux_reactor_t *r, size_t data_size,
                                       struct flux_watcher_ops *ops,
                                       flux_watcher_f fn, void *arg);
@@ -710,7 +704,7 @@ void * flux_watcher_get_data (flux_watcher_t *w);
 
 
 struct flux_watcher_ops * flux_watcher_get_ops (flux_watcher_t *w);
-# 1011 "/workspaces/python/src/_core_clean.h"
+# 1005 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_msg_handler flux_msg_handler_t;
 
 typedef void (*flux_msg_handler_f)(flux_t *h, flux_msg_handler_t *mh,
@@ -751,7 +745,7 @@ void flux_msg_handler_delvec (flux_msg_handler_t *msg_handlers[]);
 
 
 int flux_dispatch_requeue (flux_t *h);
-# 1082 "/workspaces/python/src/_core_clean.h"
+# 1076 "/workspaces/flux-python/src/_core_clean.h"
 typedef flux_t *(connector_init_f)(const char *uri,
                                    int flags,
                                    flux_error_t *errp);
@@ -772,7 +766,7 @@ struct flux_handle_ops {
 
 flux_t *flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
 void flux_handle_destroy (flux_t *hp);
-# 1133 "/workspaces/python/src/_core_clean.h"
+# 1127 "/workspaces/flux-python/src/_core_clean.h"
 struct flux_msglist *flux_msglist_create (void);
 void flux_msglist_destroy (struct flux_msglist *l);
 
@@ -786,10 +780,10 @@ const flux_msg_t *flux_msglist_next (struct flux_msglist *l);
 const flux_msg_t *flux_msglist_last (struct flux_msglist *l);
 
 int flux_msglist_count (struct flux_msglist *l);
-# 1154 "/workspaces/python/src/_core_clean.h"
+# 1148 "/workspaces/flux-python/src/_core_clean.h"
 int flux_msglist_pollevents (struct flux_msglist *l);
 int flux_msglist_pollfd (struct flux_msglist *l);
-# 1190 "/workspaces/python/src/_core_clean.h"
+# 1184 "/workspaces/flux-python/src/_core_clean.h"
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **s);
 
@@ -820,10 +814,10 @@ flux_msg_t *flux_request_encode (const char *topic, const char *s);
 
 flux_msg_t *flux_request_encode_raw (const char *topic,
                                      const void *data, int len);
-# 1256 "/workspaces/python/src/_core_clean.h"
+# 1250 "/workspaces/flux-python/src/_core_clean.h"
 int flux_response_decode (const flux_msg_t *msg, const char **topic,
                           const char **s);
-# 1267 "/workspaces/python/src/_core_clean.h"
+# 1261 "/workspaces/flux-python/src/_core_clean.h"
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
                               const void **data, int *len);
 
@@ -878,11 +872,11 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
 
 int flux_respond_error (flux_t *h, const flux_msg_t *request,
                         int errnum, const char *errstr);
-# 1349 "/workspaces/python/src/_core_clean.h"
+# 1343 "/workspaces/flux-python/src/_core_clean.h"
 flux_msg_t *flux_control_encode (int type, int status);
 
 int flux_control_decode (const flux_msg_t *msg, int *type, int *status);
-# 1410 "/workspaces/python/src/_core_clean.h"
+# 1404 "/workspaces/flux-python/src/_core_clean.h"
 typedef void (*flux_log_f)(const char *buf, int len, void *arg);
 
 
@@ -923,18 +917,7 @@ void flux_log_set_redirect (flux_t *h, flux_log_f fun, void *arg);
 
 
 const char *flux_strerror (int errnum);
-
-
-
-void flux_llog (void *arg,
-                const char *file,
-                int line,
-                const char *func,
-                const char *subsys,
-                int level,
-                const char *fmt,
-                va_list ap);
-# 1480 "/workspaces/python/src/_core_clean.h"
+# 1463 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_future flux_future_t;
 
 typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
@@ -1000,7 +983,7 @@ const char * flux_future_first_child (flux_future_t *cf);
 const char * flux_future_next_child (flux_future_t *cf);
 
 flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
-# 1558 "/workspaces/python/src/_core_clean.h"
+# 1541 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_future_and_then (flux_future_t *f,
                                      flux_continuation_f cb, void *arg);
 
@@ -1028,7 +1011,7 @@ void flux_future_continue_error (flux_future_t *prev, int errnum,
 int flux_future_fulfill_next (flux_future_t *prev,
                               void *result,
                               flux_free_f free_fn);
-# 1600 "/workspaces/python/src/_core_clean.h"
+# 1583 "/workspaces/flux-python/src/_core_clean.h"
 enum {
     FLUX_RPC_NORESPONSE = 1,
     FLUX_RPC_STREAMING = 2,
@@ -1066,9 +1049,9 @@ uint32_t flux_rpc_get_matchtag (flux_future_t *f);
 
 
 uint32_t flux_rpc_get_nodeid (flux_future_t *f);
-# 1669 "/workspaces/python/src/_core_clean.h"
+# 1652 "/workspaces/flux-python/src/_core_clean.h"
 int flux_panic (flux_t *h, uint32_t nodeid, int flags, const char *reason);
-# 1698 "/workspaces/python/src/_core_clean.h"
+# 1681 "/workspaces/flux-python/src/_core_clean.h"
 enum event_flags {
     FLUX_EVENT_PRIVATE = 1,
 };
@@ -1149,7 +1132,7 @@ flux_future_t *flux_event_publish_raw (flux_t *h,
 
 
 int flux_event_publish_get_seq (flux_future_t *f, int *seq);
-# 1813 "/workspaces/python/src/_core_clean.h"
+# 1796 "/workspaces/flux-python/src/_core_clean.h"
 enum {
     FLUX_MODSTATE_INIT = 0,
     FLUX_MODSTATE_RUNNING = 1,
@@ -1191,7 +1174,7 @@ bool flux_module_debug_test (flux_t *h, int flag, bool clear);
 
 
 int flux_module_set_running (flux_t *h);
-# 1902 "/workspaces/python/src/_core_clean.h"
+# 1885 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_attr_get (flux_t *h, const char *name);
 
 
@@ -1226,7 +1209,7 @@ const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
 
 
 int flux_get_rankbyhost (flux_t *h, const char *host);
-# 1950 "/workspaces/python/src/_core_clean.h"
+# 1933 "/workspaces/flux-python/src/_core_clean.h"
 char *flux_hostmap_lookup (flux_t *h,
                            const char *targets,
                            flux_error_t *errp);
@@ -1237,7 +1220,7 @@ char *flux_hostmap_lookup (flux_t *h,
 
 
 int flux_get_instance_starttime (flux_t *h, double *starttime);
-# 1988 "/workspaces/python/src/_core_clean.h"
+# 1971 "/workspaces/flux-python/src/_core_clean.h"
 enum flux_conf_flags {
     FLUX_CONF_INSTALLED=0,
     FLUX_CONF_INTREE=1,
@@ -1270,7 +1253,6 @@ int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **conf);
 
 
 
-
 flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error);
 
 
@@ -1290,13 +1272,13 @@ int flux_conf_vunpack (const flux_conf_t *conf,
 int flux_conf_unpack (const flux_conf_t *conf,
                       flux_error_t *error,
                       const char *fmt, ...);
-# 2072 "/workspaces/python/src/_core_clean.h"
+# 2054 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_barrier (flux_t *h, const char *name, int nprocs);
-# 2115 "/workspaces/python/src/_core_clean.h"
+# 2097 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_service_register (flux_t *h, const char *name);
-# 2127 "/workspaces/python/src/_core_clean.h"
+# 2109 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_service_unregister (flux_t *h, const char *name);
-# 2179 "/workspaces/python/src/_core_clean.h"
+# 2161 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_core_version_string (void);
 
 
@@ -1305,7 +1287,7 @@ const char *flux_core_version_string (void);
 
 
 int flux_core_version (int *major, int *minor, int *patch);
-# 2217 "/workspaces/python/src/_core_clean.h"
+# 2199 "/workspaces/flux-python/src/_core_clean.h"
 enum {
     FLUX_PLUGIN_RTLD_LAZY = 1,
     FLUX_PLUGIN_RTLD_NOW = 2,
@@ -1383,7 +1365,7 @@ flux_plugin_f flux_plugin_match_handler (flux_plugin_t *p, const char *topic);
 int flux_plugin_register (flux_plugin_t *p,
                           const char *name,
                           const struct flux_plugin_handler t[]);
-# 2304 "/workspaces/python/src/_core_clean.h"
+# 2286 "/workspaces/flux-python/src/_core_clean.h"
 int flux_plugin_aux_set (flux_plugin_t *p,
                          const char *key,
                          void *val,
@@ -1445,14 +1427,14 @@ int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
                             const char *fmt, ...);
 int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
                              const char *fmt, va_list ap);
-# 2373 "/workspaces/python/src/_core_clean.h"
+# 2355 "/workspaces/flux-python/src/_core_clean.h"
 int flux_plugin_call (flux_plugin_t *p, const char *name,
                       flux_plugin_arg_t *args);
-# 2383 "/workspaces/python/src/_core_clean.h"
+# 2365 "/workspaces/flux-python/src/_core_clean.h"
 int flux_plugin_load_dso (flux_plugin_t *p, const char *path);
-# 2416 "/workspaces/python/src/_core_clean.h"
+# 2398 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_sync_create (flux_t *h, double minimum);
-# 2448 "/workspaces/python/src/_core_clean.h"
+# 2430 "/workspaces/flux-python/src/_core_clean.h"
 bool flux_disconnect_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
 
 
@@ -1472,7 +1454,7 @@ bool flux_cancel_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
 int flux_msglist_cancel (flux_t *h,
                          struct flux_msglist *l,
                          const flux_msg_t *msg);
-# 2517 "/workspaces/python/src/_core_clean.h"
+# 2499 "/workspaces/flux-python/src/_core_clean.h"
 void flux_stats_count (flux_t *h, const char *name, ssize_t count);
 
 
@@ -1508,10 +1490,10 @@ void flux_stats_set_prefix (flux_t *h, const char *fmt, ...);
 
 
 bool flux_stats_enabled (flux_t *h, const char *metric);
-# 2600 "/workspaces/python/src/_core_clean.h"
+# 2582 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_kvsdir flux_kvsdir_t;
 typedef struct flux_kvsitr flux_kvsitr_t;
-# 2615 "/workspaces/python/src/_core_clean.h"
+# 2597 "/workspaces/flux-python/src/_core_clean.h"
 flux_kvsdir_t *flux_kvsdir_create (flux_t *handle, const char *rootref,
                                    const char *key, const char *json_str);
 void flux_kvsdir_destroy (flux_kvsdir_t *dir);
@@ -1557,7 +1539,7 @@ const char *flux_kvsdir_rootref (const flux_kvsdir_t *dir);
 
 
 char *flux_kvsdir_key_at (const flux_kvsdir_t *dir, const char *key);
-# 2688 "/workspaces/python/src/_core_clean.h"
+# 2670 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_kvs_lookup (flux_t *h, const char *ns, int flags,
                                 const char *key);
 flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
@@ -1580,14 +1562,14 @@ const char *flux_kvs_lookup_get_key (flux_future_t *f);
 
 
 int flux_kvs_lookup_cancel (flux_future_t *f);
-# 2738 "/workspaces/python/src/_core_clean.h"
+# 2720 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags);
-# 2747 "/workspaces/python/src/_core_clean.h"
+# 2729 "/workspaces/flux-python/src/_core_clean.h"
 int flux_kvs_getroot_get_treeobj (flux_future_t *f, const char **treeobj);
 int flux_kvs_getroot_get_blobref (flux_future_t *f, const char **blobref);
 int flux_kvs_getroot_get_sequence (flux_future_t *f, int *seq);
 int flux_kvs_getroot_get_owner (flux_future_t *f, uint32_t *owner);
-# 2779 "/workspaces/python/src/_core_clean.h"
+# 2761 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_kvs_txn flux_kvs_txn_t;
 
 flux_kvs_txn_t *flux_kvs_txn_create (void);
@@ -1617,7 +1599,7 @@ int flux_kvs_txn_unlink (flux_kvs_txn_t *txn, int flags,
 int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
                           const char *key, const char *ns,
                           const char *target);
-# 2857 "/workspaces/python/src/_core_clean.h"
+# 2839 "/workspaces/flux-python/src/_core_clean.h"
 enum kvs_commit_flags {
     FLUX_KVS_NO_MERGE = 1,
     FLUX_KVS_TXN_COMPACT = 2,
@@ -1635,21 +1617,21 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
 int flux_kvs_commit_get_treeobj (flux_future_t *f, const char **treeobj);
 int flux_kvs_commit_get_rootref (flux_future_t *f, const char **rootref);
 int flux_kvs_commit_get_sequence (flux_future_t *f, int *rootseq);
-# 2913 "/workspaces/python/src/_core_clean.h"
+# 2895 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_kvs_copy (flux_t *h,
                               const char *srcns,
                               const char *srckey,
                               const char *dstns,
                               const char *dstkey,
                               int commit_flags);
-# 2930 "/workspaces/python/src/_core_clean.h"
+# 2912 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_kvs_move (flux_t *h,
                               const char *srcns,
                               const char *srckey,
                               const char *dstns,
                               const char *dstkey,
                               int commit_flags);
-# 2953 "/workspaces/python/src/_core_clean.h"
+# 2935 "/workspaces/flux-python/src/_core_clean.h"
 enum kvs_op {
     FLUX_KVS_READDIR = 1,
     FLUX_KVS_READLINK = 2,
@@ -1661,7 +1643,7 @@ enum kvs_op {
     FLUX_KVS_WATCH_UNIQ = 128,
     FLUX_KVS_WATCH_APPEND = 256
 };
-# 2974 "/workspaces/python/src/_core_clean.h"
+# 2956 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
                                           uint32_t owner, int flags);
 flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
@@ -1682,7 +1664,7 @@ int flux_kvs_wait_version (flux_t *h, const char *ns, int version);
 
 
 int flux_kvs_dropcache (flux_t *h);
-# 3029 "/workspaces/python/src/_core_clean.h"
+# 3011 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_command flux_cmd_t;
 
 
@@ -1692,12 +1674,17 @@ typedef struct flux_command flux_cmd_t;
 
 
 typedef struct flux_subprocess flux_subprocess_t;
-# 3049 "/workspaces/python/src/_core_clean.h"
+
+
+typedef struct flux_subprocess_server flux_subprocess_server_t;
+# 3035 "/workspaces/flux-python/src/_core_clean.h"
 typedef enum {
     FLUX_SUBPROCESS_INIT,
+    FLUX_SUBPROCESS_EXEC_FAILED,
     FLUX_SUBPROCESS_RUNNING,
     FLUX_SUBPROCESS_EXITED,
     FLUX_SUBPROCESS_FAILED,
+
     FLUX_SUBPROCESS_STOPPED,
 } flux_subprocess_state_t;
 
@@ -1737,6 +1724,7 @@ typedef struct {
 
 
 
+
     flux_subprocess_state_f on_state_change;
     flux_subprocess_output_f on_channel_out;
     flux_subprocess_output_f on_stdout;
@@ -1753,9 +1741,39 @@ typedef struct {
     flux_subprocess_hook_f post_fork;
     void *post_fork_arg;
 } flux_subprocess_hooks_t;
-# 3120 "/workspaces/python/src/_core_clean.h"
+# 3106 "/workspaces/flux-python/src/_core_clean.h"
+flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
+                                                        const char *local_uri,
+                                                        uint32_t rank);
+
+
+typedef int (*flux_subprocess_server_auth_f) (const flux_msg_t *msg,
+                                              void *arg);
+
+
+
+
+
+
+void flux_subprocess_server_set_auth_cb (flux_subprocess_server_t *s,
+                                         flux_subprocess_server_auth_f fn,
+                                         void *arg);
+
+
+
+
+void flux_subprocess_server_stop (flux_subprocess_server_t *s);
+# 3138 "/workspaces/flux-python/src/_core_clean.h"
+int flux_subprocess_server_subprocesses_kill (flux_subprocess_server_t *s,
+                                              int signum,
+                                              double wait_time);
+
+
+int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
+                                              const char *id);
+# 3156 "/workspaces/flux-python/src/_core_clean.h"
 void flux_standard_output (flux_subprocess_t *p, const char *stream);
-# 3129 "/workspaces/python/src/_core_clean.h"
+# 3165 "/workspaces/flux-python/src/_core_clean.h"
 flux_cmd_t * flux_cmd_create (int argc, char *argv[], char **env);
 
 
@@ -1829,12 +1847,12 @@ const char *flux_cmd_getenv (const flux_cmd_t *cmd, const char *name);
 
 int flux_cmd_setcwd (flux_cmd_t *cmd, const char *cwd);
 const char *flux_cmd_getcwd (const flux_cmd_t *cmd);
-# 3215 "/workspaces/python/src/_core_clean.h"
+# 3251 "/workspaces/flux-python/src/_core_clean.h"
 int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
-# 3265 "/workspaces/python/src/_core_clean.h"
+# 3301 "/workspaces/flux-python/src/_core_clean.h"
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
-# 3288 "/workspaces/python/src/_core_clean.h"
+# 3324 "/workspaces/flux-python/src/_core_clean.h"
 flux_subprocess_t *flux_exec (flux_t *h, int flags,
                               const flux_cmd_t *cmd,
                               const flux_subprocess_ops_t *ops,
@@ -1848,7 +1866,7 @@ flux_subprocess_t *flux_local_exec (flux_reactor_t *r, int flags,
 flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,
                                const flux_subprocess_ops_t *ops);
-# 3310 "/workspaces/python/src/_core_clean.h"
+# 3346 "/workspaces/flux-python/src/_core_clean.h"
 int flux_subprocess_stream_start (flux_subprocess_t *p, const char *stream);
 int flux_subprocess_stream_stop (flux_subprocess_t *p, const char *stream);
 int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream);
@@ -1868,11 +1886,11 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
 
 
 int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
-# 3341 "/workspaces/python/src/_core_clean.h"
+# 3377 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_subprocess_read (flux_subprocess_t *p,
                                   const char *stream,
                                   int len, int *lenp);
-# 3356 "/workspaces/python/src/_core_clean.h"
+# 3392 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_subprocess_read_line (flux_subprocess_t *p,
                                        const char *stream,
                                        int *lenp);
@@ -1883,10 +1901,10 @@ const char *flux_subprocess_read_line (flux_subprocess_t *p,
 const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
                                                const char *stream,
                                                int *lenp);
-# 3376 "/workspaces/python/src/_core_clean.h"
+# 3412 "/workspaces/flux-python/src/_core_clean.h"
 int flux_subprocess_read_stream_closed (flux_subprocess_t *p,
                                         const char *stream);
-# 3395 "/workspaces/python/src/_core_clean.h"
+# 3431 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_subprocess_getline (flux_subprocess_t *p,
                                      const char *stream,
                                      int *lenp);
@@ -1906,7 +1924,7 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signo);
 
 void flux_subprocess_ref (flux_subprocess_t *p);
 void flux_subprocess_unref (flux_subprocess_t *p);
-# 3422 "/workspaces/python/src/_core_clean.h"
+# 3458 "/workspaces/flux-python/src/_core_clean.h"
 flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p);
 
 
@@ -1914,6 +1932,7 @@ flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p);
 const char *flux_subprocess_state_string (flux_subprocess_state_t state);
 
 int flux_subprocess_rank (flux_subprocess_t *p);
+
 
 
 
@@ -1954,22 +1973,7 @@ int flux_subprocess_aux_set (flux_subprocess_t *p,
 
 
 void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
-
-typedef void (*subprocess_log_f) (void *arg,
-                                  const char *file,
-                                  int line,
-                                  const char *func,
-                                  const char *subsys,
-                                  int level,
-                                  const char *fmt,
-                                  va_list args);
-
-
-
-int flux_set_default_subprocess_log (flux_t *h,
-                                     subprocess_log_f log_fn,
-                                     void *log_data);
-# 3510 "/workspaces/python/src/_core_clean.h"
+# 3530 "/workspaces/flux-python/src/_core_clean.h"
 enum job_submit_flags {
     FLUX_JOB_PRE_SIGNED = 1,
     FLUX_JOB_DEBUG = 2,
@@ -2031,10 +2035,10 @@ typedef uint64_t flux_jobid_t;
 
 
 int flux_job_id_parse (const char *s, flux_jobid_t *id);
-# 3580 "/workspaces/python/src/_core_clean.h"
+# 3600 "/workspaces/flux-python/src/_core_clean.h"
 int flux_job_id_encode (flux_jobid_t id, const char *type,
                         char *buf, size_t bufsz);
-# 3591 "/workspaces/python/src/_core_clean.h"
+# 3611 "/workspaces/flux-python/src/_core_clean.h"
 const char *flux_job_statetostr (flux_job_state_t state, const char *fmt);
 
 
@@ -2070,7 +2074,7 @@ int flux_job_wait_get_status (flux_future_t *f,
                               bool *success,
                               const char **errstr);
 int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
-# 3644 "/workspaces/python/src/_core_clean.h"
+# 3664 "/workspaces/flux-python/src/_core_clean.h"
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
                               const char *attrs_json_str,
@@ -2151,11 +2155,9 @@ flux_future_t *flux_job_result (flux_t *h, flux_jobid_t id, int flags);
 
 int flux_job_result_get (flux_future_t *f,
                          const char **json_str);
-# 3742 "/workspaces/python/src/_core_clean.h"
+# 3762 "/workspaces/flux-python/src/_core_clean.h"
 int flux_job_result_get_unpack (flux_future_t *f, const char *fmt, ...);
-# 3756 "/workspaces/python/src/_core_clean.h"
-int flux_job_timeleft (flux_t *h, flux_error_t *errp, double *timeleft);
-# 3781 "/workspaces/python/src/_core_clean.h"
+# 3787 "/workspaces/flux-python/src/_core_clean.h"
 typedef struct flux_jobspec1 flux_jobspec1_t;
 typedef flux_error_t flux_jobspec1_error_t;
 
@@ -2253,7 +2255,7 @@ char *flux_jobspec1_encode (flux_jobspec1_t *jobspec, size_t flags);
 
 flux_jobspec1_t *flux_jobspec1_decode (const char *s,
                                        flux_jobspec1_error_t *error);
-# 3892 "/workspaces/python/src/_core_clean.h"
+# 3898 "/workspaces/flux-python/src/_core_clean.h"
 flux_jobspec1_t *flux_jobspec1_from_command (int argc,
                                              char **argv,
                                              char **env,
@@ -2265,7 +2267,7 @@ flux_jobspec1_t *flux_jobspec1_from_command (int argc,
 
 
 void flux_jobspec1_destroy (flux_jobspec1_t *jobspec);
-# 3912 "/workspaces/python/src/_core_clean.h"
+# 3918 "/workspaces/flux-python/src/_core_clean.h"
 extern "Python" void message_handler_wrapper(flux_t *, flux_msg_handler_t *, const flux_msg_t *, void *);
 
 
@@ -2275,7 +2277,7 @@ extern "Python" void signal_handler_wrapper(flux_reactor_t *, flux_watcher_t *, 
 
 
 extern "Python" void continuation_callback(flux_future_t *, void *);
-# 3938 "/workspaces/python/src/_core_clean.h"
+# 3944 "/workspaces/flux-python/src/_core_clean.h"
 extern int MPIR_being_debugged;
 extern void MPIR_Breakpoint (void);
 extern int get_mpir_being_debugged (void);

--- a/src/_hostlist_preproc.h
+++ b/src/_hostlist_preproc.h
@@ -1,10 +1,10 @@
-# 1 "/workspaces/python/src/_hostlist_clean.h"
+# 1 "/workspaces/flux-python/src/_hostlist_clean.h"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
-# 1 "/workspaces/python/src/_hostlist_clean.h"
-# 33 "/workspaces/python/src/_hostlist_clean.h"
+# 1 "/workspaces/flux-python/src/_hostlist_clean.h"
+# 33 "/workspaces/flux-python/src/_hostlist_clean.h"
 struct hostlist *hostlist_create (void);
 
 void hostlist_destroy (struct hostlist *hl);
@@ -44,7 +44,7 @@ int hostlist_append_list (struct hostlist *hl1, struct hostlist *hl2);
 
 
 const char * hostlist_nth (struct hostlist * hl, int n);
-# 81 "/workspaces/python/src/_hostlist_clean.h"
+# 81 "/workspaces/flux-python/src/_hostlist_clean.h"
 int hostlist_find (struct hostlist * hl, const char *hostname);
 
 
@@ -71,13 +71,13 @@ void hostlist_sort (struct hostlist * hl);
 
 
 void hostlist_uniq (struct hostlist *hl);
-# 116 "/workspaces/python/src/_hostlist_clean.h"
+# 116 "/workspaces/flux-python/src/_hostlist_clean.h"
 const char * hostlist_first (struct hostlist *hl);
-# 126 "/workspaces/python/src/_hostlist_clean.h"
+# 126 "/workspaces/flux-python/src/_hostlist_clean.h"
 const char * hostlist_last (struct hostlist *hl);
-# 136 "/workspaces/python/src/_hostlist_clean.h"
+# 136 "/workspaces/flux-python/src/_hostlist_clean.h"
 const char * hostlist_next (struct hostlist *hl);
-# 145 "/workspaces/python/src/_hostlist_clean.h"
+# 145 "/workspaces/flux-python/src/_hostlist_clean.h"
 const char * hostlist_current (struct hostlist *hl);
 
 

--- a/src/_idset_preproc.h
+++ b/src/_idset_preproc.h
@@ -1,16 +1,16 @@
-# 1 "/workspaces/python/src/_idset_clean.h"
+# 1 "/workspaces/flux-python/src/_idset_clean.h"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
-# 1 "/workspaces/python/src/_idset_clean.h"
-# 23 "/workspaces/python/src/_idset_clean.h"
+# 1 "/workspaces/flux-python/src/_idset_clean.h"
+# 23 "/workspaces/flux-python/src/_idset_clean.h"
 enum idset_flags {
     IDSET_FLAG_AUTOGROW = 1,
     IDSET_FLAG_BRACKETS = 2,
     IDSET_FLAG_RANGE = 4,
 };
-# 37 "/workspaces/python/src/_idset_clean.h"
+# 37 "/workspaces/flux-python/src/_idset_clean.h"
 struct idset *idset_create (size_t size, int flags);
 void idset_destroy (struct idset *idset);
 
@@ -97,7 +97,7 @@ struct idset *idset_difference (const struct idset *a, const struct idset *b);
 
 
 int idset_subtract (struct idset *a, const struct idset *b);
-# 131 "/workspaces/python/src/_idset_clean.h"
+# 131 "/workspaces/flux-python/src/_idset_clean.h"
 struct idset *idset_intersect (const struct idset *a, const struct idset *b);
 
 

--- a/src/_rlist_clean.h
+++ b/src/_rlist_clean.h
@@ -18,9 +18,6 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* assume broken locale configuration and disable non-ascii characters */
-/* #undef ASSUME_BROKEN_LOCALE */
-
 /* code coverage support */
 /* #undef CODE_COVERAGE_ENABLED */
 
@@ -101,6 +98,9 @@
 
 /* Define to 1 if you have the `m' library (-lm). */
 #define HAVE_LIBM 1
+
+/* Enable PMIx bootstrap */
+/* #undef HAVE_LIBPMIX */
 
 /* Define to 1 if you have the `rt' library (-lrt). */
 /* #undef HAVE_LIBRT */
@@ -298,7 +298,7 @@
 #define PACKAGE_NAME "flux-core"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "flux-core 0.48.0"
+#define PACKAGE_STRING "flux-core 0.46.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "flux-core"
@@ -307,7 +307,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.48.0"
+#define PACKAGE_VERSION "0.46.0"
 
 /* Define remote shell program to be used by the ssh:// connector */
 #define PATH_SSH "/usr/bin/rsh"
@@ -340,7 +340,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "0.48.0"
+#define VERSION "0.46.0"
 
 /* build with jemalloc */
 /* #undef WITH_JEMALLOC */

--- a/src/_rlist_preproc.h
+++ b/src/_rlist_preproc.h
@@ -1,10 +1,10 @@
-# 1 "/workspaces/python/src/_rlist_clean.h"
+# 1 "/workspaces/flux-python/src/_rlist_clean.h"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
-# 1 "/workspaces/python/src/_rlist_clean.h"
-# 442 "/workspaces/python/src/_rlist_clean.h"
+# 1 "/workspaces/flux-python/src/_rlist_clean.h"
+# 442 "/workspaces/flux-python/src/_rlist_clean.h"
 typedef void (*flux_free_f)(void *arg);
 
 
@@ -13,7 +13,7 @@ typedef void (*flux_free_f)(void *arg);
 typedef struct {
     char text[160];
 } flux_error_t;
-# 462 "/workspaces/python/src/_rlist_clean.h"
+# 462 "/workspaces/flux-python/src/_rlist_clean.h"
 struct rlist {
     int total;
     int avail;
@@ -69,7 +69,7 @@ struct rlist *rlist_copy_allocated (const struct rlist *orig);
 struct rlist *rlist_copy_ranks (const struct rlist *rl, struct idset *ranks);
 
 struct rlist *rlist_copy_cores (const struct rlist *rl);
-# 527 "/workspaces/python/src/_rlist_clean.h"
+# 527 "/workspaces/flux-python/src/_rlist_clean.h"
 struct rlist *rlist_copy_constraint (const struct rlist *rl,
                                      json_t *constraint,
                                      flux_error_t *errp);
@@ -93,7 +93,7 @@ int rlist_remap (struct rlist *rl);
 
 
 int rlist_assign_hosts (struct rlist *rl, const char *hosts);
-# 561 "/workspaces/python/src/_rlist_clean.h"
+# 561 "/workspaces/flux-python/src/_rlist_clean.h"
 int rlist_rerank (struct rlist *rl, const char *hosts, flux_error_t *error);
 
 
@@ -150,7 +150,7 @@ struct hostlist * rlist_nodelist (const struct rlist *rl);
 
 
 struct idset * rlist_ranks (const struct rlist *rl);
-# 631 "/workspaces/python/src/_rlist_clean.h"
+# 631 "/workspaces/flux-python/src/_rlist_clean.h"
 struct idset * rlist_hosts_to_ranks (const struct rlist *rl,
                                      const char *hosts,
                                      flux_error_t *err);
@@ -185,11 +185,11 @@ struct rlist *rlist_from_R (const char *R);
 struct rlist *rlist_from_json (json_t *o, json_error_t *err);
 
 struct rlist *rlist_from_hwloc (int my_rank, const char *xml);
-# 678 "/workspaces/python/src/_rlist_clean.h"
+# 678 "/workspaces/flux-python/src/_rlist_clean.h"
 int rlist_verify (flux_error_t *error,
                   const struct rlist *expected,
                   const struct rlist *actual);
-# 696 "/workspaces/python/src/_rlist_clean.h"
+# 696 "/workspaces/flux-python/src/_rlist_clean.h"
 struct rlist * rlist_alloc (struct rlist *rl,
                             const struct rlist_alloc_info *ai,
                             flux_error_t *errp);

--- a/src/_security_preproc.h
+++ b/src/_security_preproc.h
@@ -1,10 +1,10 @@
-# 1 "/workspaces/python/src/_security_clean.h"
+# 1 "/workspaces/flux-python/src/_security_clean.h"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
-# 1 "/workspaces/python/src/_security_clean.h"
-# 35 "/workspaces/python/src/_security_clean.h"
+# 1 "/workspaces/flux-python/src/_security_clean.h"
+# 35 "/workspaces/flux-python/src/_security_clean.h"
 enum {
     FLUX_SECURITY_DISABLE_PATH_PARANOIA = 0x1,
     FLUX_SECURITY_FORCE_PATH_PARANOIA = 0x2,
@@ -26,11 +26,11 @@ int flux_security_aux_set (flux_security_t *ctx, const char *name,
              void *data, flux_security_free_f freefun);
 
 void *flux_security_aux_get (flux_security_t *ctx, const char *name);
-# 95 "/workspaces/python/src/_security_clean.h"
+# 95 "/workspaces/flux-python/src/_security_clean.h"
 enum {
     FLUX_SIGN_NOVERIFY = 1,
 };
-# 106 "/workspaces/python/src/_security_clean.h"
+# 106 "/workspaces/flux-python/src/_security_clean.h"
 const char *flux_sign_wrap (flux_security_t *ctx,
                             const void *payload, int payloadsz,
                             const char *mech_type,
@@ -45,7 +45,7 @@ const char *flux_sign_wrap_as (flux_security_t *ctx,
                                const void *payload, int payloadsz,
                                const char *mech_type,
                                int flags);
-# 132 "/workspaces/python/src/_security_clean.h"
+# 132 "/workspaces/flux-python/src/_security_clean.h"
 int flux_sign_unwrap (flux_security_t *ctx, const char *input,
                       const void **payload, int *payloadsz,
                       int64_t *userid, int flags);


### PR DESCRIPTION
This will test a base container that can compile a custom version of flux, and then build the python bindings from it

If this works, we will want to build the container (currently in docker vanessa/) here, and then extend this workflow to take a version argument OR check for releases programmatically (to be clear it should support both, and we should have the option to do either).
