### PR TITLE
Fixes the search for Flux in setup.py to eliminate symlinks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def find_flux():
             "Cannot find executable flux, which is required to be on PATH to find the install location."
         )
     # /usr/local/bin/flux --> /usr/local
-    return os.path.dirname(os.path.dirname(path))
+    return os.path.dirname(os.path.dirname(os.path.realpath(path)))
 
 
 flux_root = find_flux()


### PR DESCRIPTION
Fixes #14 

This PR wraps the path to the `flux` executable in `setup.py` with `os.path.realpath` to eliminate symlinks. This should resolve the issue we discovered on Tuolumne due to `/bin` being symlinked to `/usr/bin`.