### PR TITLE
setup.py: do not look for installed flux unless building

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -14,7 +14,7 @@ sudo mv /tmp/timezone /etc/timezone
 
 # Prepare the version file
 echo "Flux Version for pypi is ${FLUX_VERSION}"
-sed -i "s/package_version = \"develop\"/package_version = \"$FLUX_VERSION\"/" setup.py
+sed -i "s/version = \"0.0.0\"/version = \"$FLUX_VERSION\"/" pyproject.toml
 
 here=$(pwd)
 sudo apt-get update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ version = "0.0.0"
 description = "Python bindings for the flux resource manager API"
 readme = "README.md"
 keywords = ["flux", "job manager", "workload manager", "orchestration", "hpc"]
+license.file = "LICENSE"
 
 # Corresponds to the `classifiers` argument
 classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: C++",
     "Programming Language :: Python",
     "Topic :: Software Development",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+
+# These correspond to setup_requires
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "cffi>=1.1"
+]
+
+# Use setuptools
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flux-python"
+version = "0.0.0"
+description = "Python bindings for the flux resource manager API"
+readme = "README.md"
+keywords = ["flux", "job manager", "workload manager", "orchestration", "hpc"]
+
+# Corresponds to the `classifiers` argument
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Unix",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+
+# Corresponds to install_requires
+dependencies = [
+    "cffi>=1.1",
+    "pyyaml"
+]
+
+[project.urls]
+Homepage = "https://github.com/flux-framework/flux-python"
+Repository = "https://github.com/flux-framework/flux-python"
+
+# Corresponds to extras_require
+[project.optional-dependencies]
+dev = [
+    "pyyaml",
+    "jsonschema",
+    "docutils",
+    "black",
+    "IPython"
+]

--- a/setup.py
+++ b/setup.py
@@ -23,22 +23,6 @@ from setuptools import find_packages
 from setuptools import setup as _setup
 from distutils.core import setup
 
-# Metadata
-package_name = "flux-python"
-package_version = "develop"
-package_description = "Python bindings for the flux resource manager API"
-package_url = "https://github.com/flux-framework/flux-python"
-package_keywords = "flux, job manager, workload manager, orchestration, hpc"
-
-try:
-    with open("README.md") as filey:
-        package_long_description = filey.read()
-except Exception:
-    package_long_description = package_description
-
-# Setup variables for dependencies
-cffi_dep = "cffi>=1.1"
-
 # src/bindings/python
 root = os.path.dirname(os.path.abspath(__file__))
 source = os.path.join(root, "src")
@@ -65,10 +49,15 @@ def is_info_command():
     info_commands = {
         "egg_info",
         "sdist",
-        "--name",
+        "--classifiers",
         "--description",
+        "--fullname",
         "--help",
         "--help-commands",
+        "--keywords",
+        "--long-description",
+        "--name",
+        "--url",
         "--version",
     }
     # This is akin to calling --help
@@ -339,11 +328,11 @@ class HeaderCleaner:
         """
         with open(f, "r") as header:
             for l in header.readlines():
-                m = re.search('#include\s*"([^"]*)"', l)
+                m = re.search(r'#include\s*"([^"]*)"', l)
                 if m:
                     nf = find_first(self.search, m.group(1), including_path)
                     self.process_header(nf, os.path.dirname(os.path.abspath(nf)))
-                if not re.match("#\s*include", l):
+                if not re.match(r"#\s*include", l):
                     self.mega_header += l
 
         # Flag as checked
@@ -394,35 +383,10 @@ def setup():
     # This assumes relative location of Flux install
     # Now with cffi for final install
     _setup(
-        name=package_name,
-        version=package_version,
-        description=package_description,
-        long_description=package_long_description,
-        long_description_content_type="text/markdown",
-        keywords=package_keywords,
-        url=package_url,
-        setup_requires=[cffi_dep],
         packages=find_packages(),
         include_package_data=True,
         zip_safe=False,
-        install_requires=[cffi_dep, "pyyaml"],
-        extras_require={
-            "dev": ["pyyaml", "jsonschema", "docutils", "black", "IPython"]
-        },
-        classifiers=[
-            "Intended Audience :: Science/Research",
-            "Intended Audience :: Developers",
-            "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
-            "Programming Language :: C++",
-            "Programming Language :: Python",
-            "Topic :: Software Development",
-            "Topic :: Scientific/Engineering",
-            "Operating System :: Unix",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
-        ],
+        url="https://github.com/flux-framework/flux-python",
         cffi_modules=cffi_modules,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ def is_info_command():
         "--help",
         "--help-commands",
         "--keywords",
+        "--licence",
+        "--license",
         "--long-description",
         "--name",
         "--url",


### PR DESCRIPTION
Problem: `pip download` and `python3 setup.py --help` fail for the flux-python package currently when there is no local installation of Flux, because `setup.py` currently checks this first and exits with an error when Flux is not found.

I asked Claude to modify `setup.py` to skip the detection of Flux, processing of header files, etc for "info only" commands and this is result.

After this is applied `python3 setup.py --help` works (with some warnings)

Note this patch is fully AI written, so definitely needs a careful review. Happy to make modifications as necessary, but I thought this would give us a good starting point to solve a user's `pid download` issue.